### PR TITLE
Correcting parameter name to be inline with what it represents

### DIFF
--- a/SnippetExamplePractice/src/hackerrank/PreorderBST.java
+++ b/SnippetExamplePractice/src/hackerrank/PreorderBST.java
@@ -36,7 +36,7 @@ public static void main(String args[]){
 		in.close();*/
 	}
 	
-	public static String checkBST(int[] inOrderArray){
+	public static String checkBST(int[] preOrderArray){
 		Stack<Integer> s = new Stack<Integer>();
 		int lower = -1;
 		for(int i=0;i<inOrderArray.length;i++){

--- a/SnippetExamplePractice/src/hackerrank/PreorderBST.java
+++ b/SnippetExamplePractice/src/hackerrank/PreorderBST.java
@@ -39,14 +39,14 @@ public static void main(String args[]){
 	public static String checkBST(int[] preOrderArray){
 		Stack<Integer> s = new Stack<Integer>();
 		int lower = -1;
-		for(int i=0;i<inOrderArray.length;i++){
-			if(lower>-1 && inOrderArray[i] < lower){
+		for(int i=0;i<preOrderArray.length;i++){
+			if(lower>-1 && preOrderArray[i] < lower){
 				return "NO";
 			}
-			while(!s.isEmpty() && s.peek()<inOrderArray[i]){
+			while(!s.isEmpty() && s.peek() < preOrderArray[i]){
 				lower = s.pop();
 			}
-			s.push(inOrderArray[i]);
+			s.push(preOrderArray[i]);
 		}
 		return "YES";
 	}


### PR DESCRIPTION
The checkBST method takes a preOrder array as input, but the parameter name to the method is `inOrderArray`. This pull request, renames it everywhere in the method PreorderBST.checkBST.
